### PR TITLE
Updated README with correct module name to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ brew install graphviz
 
 ```PowerShell
 # install from powershell gallery
-Install-Module -Name Az -Scope CurrentUser -Repository PSGallery -Force
+Install-Module -Name AzViz -Scope CurrentUser -Repository PSGallery -Force
 
 # import the module
 Import-Module AzViz


### PR DESCRIPTION
The name of the module to install from the Powershell gallery in the README incorrectly refers to Az instead of AzViz