### PR TITLE
Fix Microsoft managed loadbalancer in other tenant issue

### DIFF
--- a/AzViz/src/private/ConvertFrom-Network.ps1
+++ b/AzViz/src/private/ConvertFrom-Network.ps1
@@ -86,9 +86,9 @@ function ConvertFrom-Network {
                             [PSCustomObject]@{
                                 fromcateg   = $fromCateg
                                 from        = $_.from
-                                to          = $to.name
-                                toCateg     = (Get-AzResource -ResourceId $to.ResourceId).ResourceType
-                                association = $to.associationType
+                                to          = if ($to.Name -notlike "gsa-*") {$to.name} else {''}
+                                toCateg     = if ($to.Name -notlike "gsa-*") {(Get-AzResource -ResourceId $to.ResourceId).ResourceType} else {''}
+                                association = if ($to.Name -notlike "gsa-*") {$to.associationType} else {''}
                                 rank        = if ($r) { $r }else { 9999 }
                             }
                         }


### PR DESCRIPTION
When trying to visualize a resource group with a resource which is dependent on Microsoft managed services like a load balancer for an Azure Firewall, Network Watcher will include them in the topology. Get-AzResource will then try to get the resource outside of this tenant which causes the process to abort because of authentication issues.

The Microsoft managed load balancers start with the name gsa-<random ID>