### PR TITLE
Feature: Add Vnet-only resource groups to graph

### DIFF
--- a/AzViz/src/private/ConvertTo-DOTLangauge.ps1
+++ b/AzViz/src/private/ConvertTo-DOTLangauge.ps1
@@ -220,9 +220,7 @@ function ConvertTo-DOTLanguage {
                 $NodesAndEdges = $nodes + $edges
             }
 
-            if (-not ($Resources) -and -not($VNets)) {
-                Write-CustomHost -String "No resources found.. re-run the command and try increasing the category depth using -CategoryDepth 2 or -CategoryDepth 3 cmdlet parameters." -Indentation 1 -Color Red -AddTime
-            } else {
+            if ($Resources -or $VNets) {
                 $ResourceGroupLocation = (Get-AzResourceGroup -Name $Target.Name -Verbose:$false).Location
                 $ResourceGroupSubGraphName = [string]::Concat($(Remove-SpecialChars -String $Target.Name -SpecialChars '() []{}&-'), $Counter)
                 $ResourceGroupSubGraphNameLabel = Get-ImageLabel -Type "ResourceGroups" -Row1 "ResourceGroup: $(Remove-SpecialChars -String $Target.name)" -Row2 "Location: $($ResourceGroupLocation)"
@@ -241,7 +239,8 @@ function ConvertTo-DOTLanguage {
                     $NetworkLayout
                     $NodesAndEdges
                 }
-
+            } else {
+                Write-CustomHost -String "No resources found.. re-run the command and try increasing the category depth using -CategoryDepth 2 or -CategoryDepth 3 cmdlet parameters." -Indentation 1 -Color Red -AddTime
             }
             #endregion plotting-edges-to-nodes
         }

--- a/AzViz/src/private/ConvertTo-DOTLangauge.ps1
+++ b/AzViz/src/private/ConvertTo-DOTLangauge.ps1
@@ -218,7 +218,11 @@ function ConvertTo-DOTLanguage {
                 }
 
                 $NodesAndEdges = $nodes + $edges
+            }
 
+            if (-not ($Resources) -and -not($VNets)) {
+                Write-CustomHost -String "No resources found.. re-run the command and try increasing the category depth using -CategoryDepth 2 or -CategoryDepth 3 cmdlet parameters." -Indentation 1 -Color Red -AddTime
+            } else {
                 $ResourceGroupLocation = (Get-AzResourceGroup -Name $Target.Name -Verbose:$false).Location
                 $ResourceGroupSubGraphName = [string]::Concat($(Remove-SpecialChars -String $Target.Name -SpecialChars '() []{}&-'), $Counter)
                 $ResourceGroupSubGraphNameLabel = Get-ImageLabel -Type "ResourceGroups" -Row1 "ResourceGroup: $(Remove-SpecialChars -String $Target.name)" -Row2 "Location: $($ResourceGroupLocation)"
@@ -238,9 +242,6 @@ function ConvertTo-DOTLanguage {
                     $NodesAndEdges
                 }
 
-            }
-            else {
-                Write-CustomHost -String "No resources found.. re-run the command and try increasing the category depth using -CategoryDepth 2 or -CategoryDepth 3 cmdlet parameters." -Indentation 1 -Color Red -AddTime
             }
             #endregion plotting-edges-to-nodes
         }


### PR DESCRIPTION
Currently when fetching resources through network watcher and ARM, it will skip virtualNetwork resources. In the `ConvertTo-DOTLanguage` it will fetch all virtualNetworks and subnets, but as long as ARM and NetworkWatcher does not return any resources it will not add virtualNetworks to the graph.

This PR will make sure that resource groups that contain only Vnet (and subnets) also get added to the graph.