### PR TITLE
Avoid escaping resource group and subscription labels

### DIFF
--- a/AzViz/src/private/ConvertTo-DOTLangauge.ps1
+++ b/AzViz/src/private/ConvertTo-DOTLangauge.ps1
@@ -224,7 +224,7 @@ function ConvertTo-DOTLanguage {
             if ($Resources -or $VNets) {
                 $ResourceGroupLocation = (Get-AzResourceGroup -Name $Target.Name -Verbose:$false).Location
                 $ResourceGroupSubGraphName = [string]::Concat($(Remove-SpecialChars -String $Target.Name -SpecialChars $SpecialChars), $Counter)
-                $ResourceGroupSubGraphNameLabel = Get-ImageLabel -Type "ResourceGroups" -Row1 "ResourceGroup: $(Remove-SpecialChars -String $Target.name -SpecialChars $SpecialChars)" -Row2 "Location: $($ResourceGroupLocation)"
+                $ResourceGroupSubGraphNameLabel = Get-ImageLabel -Type "ResourceGroups" -Row1 "ResourceGroup: $($Target.name)" -Row2 "Location: $($ResourceGroupLocation)"
                 $ResourceGroupSubGraphAttributes = @{
                     label    = $ResourceGroupSubGraphNameLabel;
                     labelloc = 't';
@@ -284,7 +284,7 @@ function ConvertTo-DOTLanguage {
 
             $graph = Graph -Name 'Visualization' -Attributes $VisualizationAttributes -ScriptBlock {
                 
-                $MainGraphLabel = Get-ImageLabel -Type "Subscriptions" -Row1 "Subscription: $(Remove-SpecialChars -String $Subscription.name -SpecialChars $SpecialChars)" -Row2 "Id: $($Subscription.Id)"
+                $MainGraphLabel = Get-ImageLabel -Type "Subscriptions" -Row1 "Subscription: $($Subscription.name)" -Row2 "Id: $($Subscription.Id)"
                 $MainGraphAttributes = @{
                     label    = $MainGraphLabel
                     fontsize = "9"


### PR DESCRIPTION
For me it looks like labels in DOT does not have to escape special characters. Im not proficient in DOT language so if theres a reason that labels for resource groups and subscription are escaped, please cancel this PR.

This PR will remove escaping of special characters when setting the label for resource group and subscription. This is the same behaviour that is already implemented for VNET and Subnets ([#65](https://github.com/PrateekKumarSingh/AzViz/blob/e3683bab47a667f33acbb38a520536f9e049f363/AzViz/src/private/ConvertTo-DOTLangauge.ps1#L65) / [#88](https://github.com/PrateekKumarSingh/AzViz/blob/e3683bab47a667f33acbb38a520536f9e049f363/AzViz/src/private/ConvertTo-DOTLangauge.ps1#L88)).

I have tested this locally on macOS, and works as expected there with my Azure environment.