### PR TITLE
Add flexibility finding the `dot` binary

### DIFF
--- a/AzViz/src/private/Get-DOTExecutable.ps1
+++ b/AzViz/src/private/Get-DOTExecutable.ps1
@@ -6,6 +6,7 @@ function Get-DOTExecutable {
         '/usr/local/bin/dot',
         '/usr/bin/dot'
     )
+    $PossibleGraphVizPaths += (Get-Command -Type Application -Name dot).Source
 
     $GraphViz = Resolve-Path -path $PossibleGraphVizPaths -ErrorAction SilentlyContinue | Get-Item | Where-Object BaseName -eq 'dot' | Select-Object -First 1
 

--- a/AzViz/src/public/Export-AzViz.ps1
+++ b/AzViz/src/public/Export-AzViz.ps1
@@ -271,7 +271,7 @@ function Export-AzViz {
         if ($graph) {
             @"
 strict $graph
-"@ | Export-PSGraph -ShowGraph:$Show -OutputFormat $OutputFormat -DestinationPath $OutputFilePath -OutVariable output |
+"@ | Export-PSGraph -GraphVizPath $GraphViz.FullName -ShowGraph:$Show -OutputFormat $OutputFormat -DestinationPath $OutputFilePath -OutVariable output |
             Out-Null
             Write-CustomHost "Visualization exported to path: $($output.fullname)" -Indentation 0 -color Magenta -AddTime
             Write-CustomHost "Finished Azure visualization." -Indentation 0 -color Magenta -AddTime


### PR DESCRIPTION
Get-DotExecutable.ps1:
This function has a few hardcoded paths to `dot`. On macOS some package
mangers install to a different location in order to avoid overwriting
system binaries. The package manager directory is in $env:PATH. By
adding a call Get-Command in this function we can search for `dot` in
the system's PATH and have a higher success of finding it.

Export-AzViz.ps1:
Similarly it seems like the PSGraph module use a few hardcoded paths,
too. Fortunately they include a -GraphVizPath parameter that allows us
to specify the path. Since we already got the path for error checking
earlier in in this module we can simply reuse that in the call to
Export-PsGraph.