### PR TITLE
Fix: Update required modules

### DIFF
--- a/AzViz/AzViz.psd1
+++ b/AzViz/AzViz.psd1
@@ -53,6 +53,8 @@ RequiredModules = @(
     @{ModuleName = 'PSGraph'; ModuleVersion = '2.1.38.27'}
     @{ModuleName = 'Az.Accounts';       ModuleVersion = '2.2.8'}
     @{ModuleName = 'Az.Resources';       ModuleVersion = '3.4.1'}
+    @{ModuleName = 'Az.Network'; ModuleVersion = '4.8.0'}
+    @{ModuleName = 'Az.Compute'; ModuleVersion = '4.13.0'}
 )
 
 # Assemblies that must be loaded prior to importing this module

--- a/AzViz/AzViz.psd1
+++ b/AzViz/AzViz.psd1
@@ -53,8 +53,8 @@ RequiredModules = @(
     @{ModuleName = 'PSGraph'; ModuleVersion = '2.1.38.27'}
     @{ModuleName = 'Az.Accounts';       ModuleVersion = '2.2.8'}
     @{ModuleName = 'Az.Resources';       ModuleVersion = '3.4.1'}
-    @{ModuleName = 'Az.Network'; ModuleVersion = '4.8.0'}
-    @{ModuleName = 'Az.Compute'; ModuleVersion = '4.13.0'}
+    @{ModuleName = 'Az.Network'; ModuleVersion = '4.11.0'}
+    @{ModuleName = 'Az.Compute'; ModuleVersion = '4.17.0'}
 )
 
 # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
The cmdlets listed below are used by AzViz but the modules that contains these cmdlets are not a part of the required modules in `AzViz.psd1`. This PR adds the latest version of those module to the required modules.

This has been tested locally on my mac.

```
# Az.Network
Get-AzNetworkInterface
Get-AzNetworkWatcher
Get-AzNetworkWatcherTopology
Get-AzVirtualNetwork

# Az.Compute
Get-AzVM
```