### PR TITLE
fix: add check to make sure category is not null

### DIFF
--- a/AzViz/src/private/ConvertTo-DOTLangauge.ps1
+++ b/AzViz/src/private/ConvertTo-DOTLangauge.ps1
@@ -179,7 +179,14 @@ function ConvertTo-DOTLanguage {
                         }
                         elseif ($LabelVerbosity -eq 2) {
                             $nodes += Get-ImageNode -Name "$fromcateg/$from".tolower() -Rows ($from, $fromcateg) -Type $fromcateg -ErrorAction SilentlyContinue
-                            $nodes += Get-ImageNode -Name "$tocateg/$to".tolower() -Rows ($to, $toCateg) -Type $tocateg -ErrorAction SilentlyContinue
+
+                            # If this resource is a network association, it may not have the $toCateg defined, so it will be null.
+                            # This will fail inside Get-ImageNode when its trying to split and format the string
+                            if ([String]::IsNullOrEmpty($tocateg)) {
+                                $nodes += Get-ImageNode -Name "$tocateg/$to".tolower() -Rows $to -Type $tocateg -ErrorAction SilentlyContinue
+                            } else {
+                                $nodes += Get-ImageNode -Name "$tocateg/$to".tolower() -Rows ($to, $toCateg) -Type $tocateg -ErrorAction SilentlyContinue
+                            }
                         }
                     }
                     else {


### PR DESCRIPTION
This PR adds a check to see if `$toCateg` is not empty or null before getting icon if the label verbosity is 2.

If there are multiple values passed to `-Rows` in `Get-ImageNode` it will try to split by `/` (with max 2 substrings) and format it into a string for all values after the first one. If the value cant be splitted, the formatting will fail and throw an error:

`Get-ImageNode : Error formatting a string: Index (zero based) must be greater than or equal to zero and less than the size of the argument list..`

In my case, when the NetworkWatcher is getting associations from an application gateway, these associations dont have a type/provider/category, and it will fail when splitting. Therefor we check to see if `$toCateg` is not empty or null and leave it out if it is.

this might also fix #64