### PR TITLE
added path for m1 homebrew installation

### DIFF
--- a/AzViz/src/private/Get-DOTExecutable.ps1
+++ b/AzViz/src/private/Get-DOTExecutable.ps1
@@ -4,7 +4,8 @@ function Get-DOTExecutable {
         'C:\Program Files\NuGet\Packages\Graphviz*\dot.exe',
         'C:\program files*\GraphViz*\bin\dot.exe',
         '/usr/local/bin/dot',
-        '/usr/bin/dot'
+        '/usr/bin/dot',
+        '/opt/homebrew/bin/dot'
     )
     $PossibleGraphVizPaths += (Get-Command -Type Application -Name dot).Source
 


### PR DESCRIPTION
Currently tool doesn't pick up homebrew path on M1 mac which is `'/opt/homebrew/bin/dot'` which means it would fail to detect `GraphViz` installation even if it is installed. 

Adding extra path for M1 homebrew installation as mentioned in https://github.com/PrateekKumarSingh/AzViz/issues/94